### PR TITLE
Do not hardcode the day names

### DIFF
--- a/app/src/main/java/app/fit/fitndflow/domain/Utils.java
+++ b/app/src/main/java/app/fit/fitndflow/domain/Utils.java
@@ -5,6 +5,7 @@ import android.content.Context;
 
 import com.fit.fitndflow.R;
 
+import java.text.DateFormatSymbols;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
@@ -47,10 +48,9 @@ public class Utils {
 
         int dayOfWeek = calendar.get(Calendar.DAY_OF_WEEK);
 
-        String[] dayNames = {context.getString(R.string.sunday), context.getString(R.string.monday), context.getString(R.string.tuesday), context.getString(R.string.wednesday),
-                context.getString(R.string.thursday), context.getString(R.string.friday), context.getString(R.string.saturday)};
+        String[] dayNames = new DateFormatSymbols().getShortWeekdays();
 
-        return dayNames[dayOfWeek - 1].substring(0, 3);
+        return dayNames[dayOfWeek];
     }
 
     public static boolean isYesterday(Date date) {

--- a/app/src/main/java/app/fit/fitndflow/domain/Utils.java
+++ b/app/src/main/java/app/fit/fitndflow/domain/Utils.java
@@ -42,7 +42,7 @@ public class Utils {
         return dateFormat.format(date);
     }
 
-    public static String dayOfWeek(Date date, Context context) {
+    public static String dayOfWeek(Date date) {
         Calendar calendar = Calendar.getInstance();
         calendar.setTime(date);
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -65,13 +65,6 @@
     <string name="repetitions">Repetitions</string>
     <string name="Weight_kg">Weight (Kg)</string>
     <string name="add_note">Add Note</string>
-    <string name="sunday">Sunday</string>
-    <string name="monday">Monday</string>
-    <string name="tuesday">Tuesday</string>
-    <string name="wednesday">Wednesday</string>
-    <string name="thursday">Thursday</string>
-    <string name="friday">Friday</string>
-    <string name="saturday">Saturday</string>
     <string name="escriba_texto">Write a text...</string>
     <string name="successfully_added">Successfully added</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,13 +65,6 @@
     <string name="repetitions">Repeticiones</string>
     <string name="Weight_kg">Peso (Kg)</string>
     <string name="add_note">Añadir Nota</string>
-    <string name="sunday">Domingo</string>
-    <string name="monday">Lunes</string>
-    <string name="tuesday">Martes</string>
-    <string name="wednesday">Miércoles</string>
-    <string name="thursday">Jueves</string>
-    <string name="friday">Viernes</string>
-    <string name="saturday">Sábado</string>
     <string name="escriba_texto">Escriba texto...</string>
     <string name="successfully_added">Añadido correctamente</string>
 


### PR DESCRIPTION
The Java-standard `DateFormatSymbols` class already provides the day names in all languages, both in their long form via `getWeekdays()` and their short form (like they are used in the app) vis `getShortWeekdays()`, so there's no need to define them again.

Note: I didn't test this because I can't build the app myself.